### PR TITLE
Add job_tracker to table names; add ORDER BY to table lists

### DIFF
--- a/api/__tests__/applicationApi.test.js
+++ b/api/__tests__/applicationApi.test.js
@@ -28,7 +28,7 @@ describe('Application Routes', () => {
 
       expect(response.status).toBe(201);
       expect(response.body).toEqual(newApplication);
-      expect(db.create).toHaveBeenCalledWith('application', newApplication);
+      expect(db.create).toHaveBeenCalledWith('job_tracker.application', newApplication);
     });
 
     it('should handle errors during application creation', async () => {
@@ -51,7 +51,7 @@ describe('Application Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(application);
-      expect(db.read).toHaveBeenCalledWith('application', '1');
+      expect(db.read).toHaveBeenCalledWith('job_tracker.application', '1');
     });
 
     it('should return 404 if application not found', async () => {
@@ -83,7 +83,7 @@ describe('Application Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(updatedApplication);
-      expect(db.update).toHaveBeenCalledWith('application', '1', { application_date: '2023-10-27' });
+      expect(db.update).toHaveBeenCalledWith('job_tracker.application', '1', { application_date: '2023-10-27' });
     });
 
     it('should return 404 if application not found during update', async () => {
@@ -115,7 +115,7 @@ describe('Application Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(deletedApplication);
-      expect(db.remove).toHaveBeenCalledWith('application', '1');
+      expect(db.remove).toHaveBeenCalledWith('job_tracker.application', '1');
     });
 
     it('should return 404 if application not found during delete', async () => {
@@ -147,7 +147,7 @@ describe('Application Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(applications);
-      expect(db.innerjoin).toHaveBeenCalledWith('application',
+      expect(db.innerjoin).toHaveBeenCalledWith('job_tracker.application',
         [
           'application.id',
           'application.application_date',

--- a/api/__tests__/companyApi.test.js
+++ b/api/__tests__/companyApi.test.js
@@ -28,7 +28,7 @@ describe('Company Routes', () => {
 
       expect(response.status).toBe(201);
       expect(response.body).toEqual(newCompany);
-      expect(db.create).toHaveBeenCalledWith('company', newCompany);
+      expect(db.create).toHaveBeenCalledWith('job_tracker.company', newCompany);
     });
 
     it('should handle errors during company creation', async () => {
@@ -51,7 +51,7 @@ describe('Company Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(company);
-      expect(db.read).toHaveBeenCalledWith('company', '1');
+      expect(db.read).toHaveBeenCalledWith('job_tracker.company', '1');
     });
 
     it('should return 404 if company not found', async () => {
@@ -83,7 +83,7 @@ describe('Company Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(updatedCompany);
-      expect(db.update).toHaveBeenCalledWith('company', '1', { name: 'Globex Corp' });
+      expect(db.update).toHaveBeenCalledWith('job_tracker.company', '1', { name: 'Globex Corp' });
     });
 
     it('should return 404 if company not found during update', async () => {
@@ -115,7 +115,7 @@ describe('Company Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(deletedCompany);
-      expect(db.remove).toHaveBeenCalledWith('company', '1');
+      expect(db.remove).toHaveBeenCalledWith('job_tracker.company', '1');
     });
 
     it('should return 404 if company not found during delete', async () => {
@@ -147,7 +147,7 @@ describe('Company Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(companies);
-      expect(db.list).toHaveBeenCalledWith('company');
+      expect(db.list).toHaveBeenCalledWith('job_tracker.company', 'company_name');
     });
 
     it('should handle errors during company listing', async () => {

--- a/api/__tests__/contactApi.test.js
+++ b/api/__tests__/contactApi.test.js
@@ -28,7 +28,7 @@ describe('Contact Routes', () => {
 
       expect(response.status).toBe(201);
       expect(response.body).toEqual(newContact);
-      expect(db.create).toHaveBeenCalledWith('contact', newContact);
+      expect(db.create).toHaveBeenCalledWith('job_tracker.contact', newContact);
     });
 
     it('should handle errors during contact creation', async () => {
@@ -51,7 +51,7 @@ describe('Contact Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(contact);
-      expect(db.read).toHaveBeenCalledWith('contact', '1');
+      expect(db.read).toHaveBeenCalledWith('job_tracker.contact', '1');
     });
 
     it('should return 404 if contact not found', async () => {
@@ -83,7 +83,7 @@ describe('Contact Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(updatedContact);
-      expect(db.update).toHaveBeenCalledWith('contact', '1', { name: 'Jane Doe' });
+      expect(db.update).toHaveBeenCalledWith('job_tracker.contact', '1', { name: 'Jane Doe' });
     });
 
     it('should return 404 if contact not found during update', async () => {
@@ -115,7 +115,7 @@ describe('Contact Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(deletedContact);
-      expect(db.remove).toHaveBeenCalledWith('contact', '1');
+      expect(db.remove).toHaveBeenCalledWith('job_tracker.contact', '1');
     });
 
     it('should return 404 if contact not found during delete', async () => {
@@ -147,7 +147,7 @@ describe('Contact Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(contacts);
-      expect(db.list).toHaveBeenCalledWith('contact');
+      expect(db.list).toHaveBeenCalledWith('job_tracker.contact', 'contact_name');
     });
 
     it('should handle errors during contact listing', async () => {

--- a/api/__tests__/jobApi.test.js
+++ b/api/__tests__/jobApi.test.js
@@ -28,7 +28,7 @@ describe('Job Routes', () => {
 
       expect(response.status).toBe(201);
       expect(response.body).toEqual(newJob);
-      expect(db.create).toHaveBeenCalledWith('job', newJob);
+      expect(db.create).toHaveBeenCalledWith('job_tracker.job', newJob);
     });
 
     it('should handle errors during job creation', async () => {
@@ -51,7 +51,7 @@ describe('Job Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(job);
-      expect(db.read).toHaveBeenCalledWith('job', '1');
+      expect(db.read).toHaveBeenCalledWith('job_tracker.job', '1');
     });
 
     it('should return 404 if job not found', async () => {
@@ -83,7 +83,7 @@ describe('Job Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(updatedJob);
-      expect(db.update).toHaveBeenCalledWith('job', '1', { title: 'Senior Software Engineer' });
+      expect(db.update).toHaveBeenCalledWith('job_tracker.job', '1', { title: 'Senior Software Engineer' });
     });
 
     it('should return 404 if job not found during update', async () => {
@@ -115,7 +115,7 @@ describe('Job Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(deletedJob);
-      expect(db.remove).toHaveBeenCalledWith('job', '1');
+      expect(db.remove).toHaveBeenCalledWith('job_tracker.job', '1');
     });
 
     it('should return 404 if job not found during delete', async () => {
@@ -147,7 +147,7 @@ describe('Job Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(jobs);
-      expect(db.innerjoin).toHaveBeenCalledWith('job',
+      expect(db.innerjoin).toHaveBeenCalledWith('job_tracker.job',
         [
           'job.id',
           'job.title',

--- a/api/applicationApi.js
+++ b/api/applicationApi.js
@@ -4,7 +4,7 @@ const db = require('../db/db');
 
 router.post('/', async (req, res) => {
   try {
-    const newApplication = await db.create('application', req.body);
+    const newApplication = await db.create('job_tracker.application', req.body);
 
     res.status(201).json(newApplication);
   } catch (err) {
@@ -14,7 +14,7 @@ router.post('/', async (req, res) => {
 
 router.get('/:id', async (req, res) => {
   try {
-    const application = await db.read('application', req.params.id);
+    const application = await db.read('job_tracker.application', req.params.id);
 
     if (!application) {
       return res.status(404).json({ error: 'Application not found' });
@@ -28,7 +28,7 @@ router.get('/:id', async (req, res) => {
 
 router.patch('/:id', async (req, res) => {
   try {
-    const updatedApplication = await db.update('application', req.params.id, req.body);
+    const updatedApplication = await db.update('job_tracker.application', req.params.id, req.body);
 
     if (!updatedApplication) {
       return res.status(404).json({ error: 'Application not found' });
@@ -42,7 +42,7 @@ router.patch('/:id', async (req, res) => {
 
 router.delete('/:id', async (req, res) => {
   try {
-    const deletedApplication = await db.remove('application', req.params.id);
+    const deletedApplication = await db.remove('job_tracker.application', req.params.id);
 
     if (!deletedApplication) {
       return res.status(404).json({ error: 'Application not found' });
@@ -79,7 +79,7 @@ router.get('/', async (req, res) => {
   ];
 
   try {
-    const applications = await db.innerjoin('application', data, fk);
+    const applications = await db.innerjoin('job_tracker.application', data, fk);
 
     res.json(applications);
   } catch(err){

--- a/api/companyApi.js
+++ b/api/companyApi.js
@@ -4,7 +4,7 @@ const db = require('../db/db');
 
 router.post('/', async (req, res) => {
   try {
-    const newCompany = await db.create('company', req.body);
+    const newCompany = await db.create('job_tracker.company', req.body);
 
     res.status(201).json(newCompany);
   } catch (err) {
@@ -14,7 +14,7 @@ router.post('/', async (req, res) => {
 
 router.get('/:id', async (req, res) => {
   try {
-    const company = await db.read('company', req.params.id);
+    const company = await db.read('job_tracker.company', req.params.id);
 
     if (!company) {
       return res.status(404).json({ error: 'Company not found' });
@@ -28,7 +28,7 @@ router.get('/:id', async (req, res) => {
 
 router.put('/:id', async (req, res) => {
   try {
-    const updatedCompany = await db.update('company', req.params.id, req.body);
+    const updatedCompany = await db.update('job_tracker.company', req.params.id, req.body);
 
     if (!updatedCompany) {
       return res.status(404).json({ error: 'Company not found' });
@@ -42,7 +42,7 @@ router.put('/:id', async (req, res) => {
 
 router.delete('/:id', async (req, res) => {
   try {
-    const deletedCompany = await db.remove('company', req.params.id);
+    const deletedCompany = await db.remove('job_tracker.company', req.params.id);
 
     if (!deletedCompany) {
       return res.status(404).json({ error: 'Company not found' });
@@ -56,7 +56,7 @@ router.delete('/:id', async (req, res) => {
 
 router.get('/', async (req, res) => {
   try {
-    const companies = await db.list('company');
+    const companies = await db.list('job_tracker.company', 'company_name');
 
     res.json(companies);
   } catch(err){

--- a/api/contactApi.js
+++ b/api/contactApi.js
@@ -4,7 +4,7 @@ const db = require('../db/db');
 
 router.post('/', async (req, res) => {
   try {
-    const newContact = await db.create('contact', req.body);
+    const newContact = await db.create('job_tracker.contact', req.body);
 
     res.status(201).json(newContact);
   } catch (err) {
@@ -14,7 +14,7 @@ router.post('/', async (req, res) => {
 
 router.get('/:id', async (req, res) => {
   try {
-    const contact = await db.read('contact', req.params.id);
+    const contact = await db.read('job_tracker.contact', req.params.id);
 
     if (!contact) {
       return res.status(404).json({ error: 'Contact not found' });
@@ -28,7 +28,7 @@ router.get('/:id', async (req, res) => {
 
 router.put('/:id', async (req, res) => {
   try {
-    const updatedContact = await db.update('contact', req.params.id, req.body);
+    const updatedContact = await db.update('job_tracker.contact', req.params.id, req.body);
 
     if (!updatedContact) {
       return res.status(404).json({ error: 'Contact not found' });
@@ -42,7 +42,7 @@ router.put('/:id', async (req, res) => {
 
 router.delete('/:id', async (req, res) => {
   try {
-    const deletedContact = await db.remove('contact', req.params.id);
+    const deletedContact = await db.remove('job_tracker.contact', req.params.id);
 
     if (!deletedContact) {
       return res.status(404).json({ error: 'Contact not found' });
@@ -56,7 +56,7 @@ router.delete('/:id', async (req, res) => {
 
 router.get('/', async (req, res) => {
   try {
-    const contacts = await db.list('contact');
+    const contacts = await db.list('job_tracker.contact', 'contact_name');
 
     res.json(contacts);
   } catch(err){

--- a/api/jobApi.js
+++ b/api/jobApi.js
@@ -4,7 +4,7 @@ const db = require('../db/db');
 
 router.post('/', async (req, res) => {
   try {
-    const newJob = await db.create('job', req.body);
+    const newJob = await db.create('job_tracker.job', req.body);
 
     res.status(201).json(newJob);
   } catch (err) {
@@ -14,7 +14,7 @@ router.post('/', async (req, res) => {
 
 router.get('/:id', async (req, res) => {
   try {
-    const job = await db.read('job', req.params.id);
+    const job = await db.read('job_tracker.job', req.params.id);
 
     if (!job) {
       return res.status(404).json({ error: 'Job not found' });
@@ -28,7 +28,7 @@ router.get('/:id', async (req, res) => {
 
 router.put('/:id', async (req, res) => {
   try {
-    const updatedJob = await db.update('job', req.params.id, req.body);
+    const updatedJob = await db.update('job_tracker.job', req.params.id, req.body);
 
     if (!updatedJob) {
       return res.status(404).json({ error: 'Job not found' });
@@ -42,7 +42,7 @@ router.put('/:id', async (req, res) => {
 
 router.delete('/:id', async (req, res) => {
   try {
-    const deletedJob = await db.remove('job', req.params.id);
+    const deletedJob = await db.remove('job_tracker.job', req.params.id);
 
     if (!deletedJob) {
       return res.status(404).json({ error: 'Job not found' });
@@ -71,7 +71,7 @@ router.get('/', async (req, res) => {
   ];
 
   try {
-    const jobs = await db.innerjoin('job', data, fk);
+    const jobs = await db.innerjoin('job_tracker.job', data, fk);
 
     res.json(jobs);
   } catch(err){

--- a/db/__tests__/db.test.js
+++ b/db/__tests__/db.test.js
@@ -95,7 +95,7 @@ describe('CRUD operations', () => {
 
     const result = await list(table);
     expect(result).toEqual(expectedResult);
-    expect(client.query).toHaveBeenCalledWith('SELECT * FROM test_table', []);
+    expect(client.query).toHaveBeenCalledWith('SELECT * FROM test_table ORDER BY id', []);
   });
 
     it('Should handle query errors', async () => {

--- a/db/db.js
+++ b/db/db.js
@@ -62,8 +62,8 @@ async function remove(table, id) {
   return result.rows[0];
 }
 
-async function list(table) {
-  const queryText = `SELECT * FROM ${table}`;
+async function list(table, orderBy='id') {
+  const queryText = `SELECT * FROM ${table} ORDER BY ${orderBy}`;
 
   const result = await query(queryText, []);
 


### PR DESCRIPTION
Based on user feedback, I updated `db.js` to include the schema name `job_tracker` with the table names.

Updated the table list commands to accept an ORDER BY. Defaults to 'id' if not provided.

Update test files